### PR TITLE
Remove babel as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
   "devDependencies": {
     "eslint": "^4.19.1",
     "http-server": "^0.11.1",
-    "webpack": "^3.10.0"
-  },
-  "dependencies": {
+    "webpack": "^3.10.0",
     "@babel/core": "^7.0.0-beta.51",
     "@babel/preset-env": "^7.0.0-beta.51",
     "babel-loader": "^8.0.0-beta.3"
-  }
+  },
+  "dependencies": {}
 }


### PR DESCRIPTION
Babel isn't required as a core dependency. More of a dev dependency. Would actually be nicer as an optional peer dependency. Since we do not needing babel to use this plugin, I'm moving it so that we do not have a bloated node_modules tree.