### PR TITLE
Config validation

### DIFF
--- a/src/Bullet.js
+++ b/src/Bullet.js
@@ -12,7 +12,7 @@ let bulletID = 0;
 class Bullet extends Phaser.GameObjects.Sprite {
   /**
    * Create a new `Bullet` object. Bullets are used by the `Weapon` class, and are normal Sprites,
-   * with a few extra properties in the data object to handle Weapon specific features.
+   * with a few extra properties in the data manager to handle Weapon specific features.
    *
    * @param {Phaser.Scene} scene - A reference to the currently running scene.
    * @param {number} x - The x coordinate (in world space) to position the Particle at.
@@ -52,8 +52,8 @@ class Bullet extends Phaser.GameObjects.Sprite {
     this.setVisible(true);
     this.body.enable = true;
     this.body.reset(x, y);
-    this.body.debugShowBody = this.data.bulletManager.debugPhysics;
-    this.body.debugShowVelocity = this.data.bulletManager.debugPhysics;
+    this.body.debugShowBody = this.getData('bulletManager').debugPhysics;
+    this.body.debugShowVelocity = this.getData('bulletManager').debugPhysics;
   }
 
   /**
@@ -78,11 +78,11 @@ class Bullet extends Phaser.GameObjects.Sprite {
     // events with a flag and some math.
     // Both of those are probably premature optimizations.
     if (this.getData('timeEvent') !== null) {
-      this.data.timeEvent.destroy();
-      this.data.timeEvent = null;
+      this.getData('timeEvent').destroy();
+      this.setData('timeEvent', null);
     }
 
-    this.data.bulletManager.eventEmitter.emit('kill', this);
+    this.getData('bulletManager').eventEmitter.emit('kill', this);
 
     return this;
   }
@@ -97,30 +97,30 @@ class Bullet extends Phaser.GameObjects.Sprite {
       return;
     }
 
-    if (this.data.killType > consts.KILL_LIFESPAN) {
-      if (this.data.killType === consts.KILL_DISTANCE) {
+    if (this.getData('killType') > consts.KILL_LIFESPAN) {
+      if (this.getData('killType') === consts.KILL_DISTANCE) {
         if (
-          new Phaser.Math.Vector2(this.data.fromX, this.data.fromY).distance(this) >
-          this.data.killDistance
+          new Phaser.Math.Vector2(this.getData('fromX'), this.getData('fromY')).distance(this) >
+          this.getData('killDistance')
         ) {
           this.kill();
         }
       } else if (
         !Phaser.Geom.Intersects.RectangleToRectangle(
-          this.data.bulletManager.bulletBounds,
-          this.body.getBounds(this.data.bodyBounds)
+          this.getData('bulletManager').bulletBounds,
+          this.body.getBounds(this.getData('bodyBounds'))
         )
       ) {
         this.kill();
       }
     }
 
-    if (this.data.rotateToVelocity) {
+    if (this.getData('rotateToVelocity')) {
       this.rotation = this.body.velocity.atan();
     }
 
-    if (this.data.bulletManager.bulletWorldWrap) {
-      this.scene.physics.world.wrap(this, this.data.bulletManager.bulletWorldWrapPadding);
+    if (this.getData('bulletManager').bulletWorldWrap) {
+      this.scene.physics.world.wrap(this, this.getData('bulletManager').bulletWorldWrapPadding);
     }
   }
 }

--- a/src/Weapon.js
+++ b/src/Weapon.js
@@ -361,6 +361,14 @@ class Weapon {
      */
     this._rotatedPoint = new Phaser.Math.Vector2();
 
+    /**
+     * Log level for this weapon. Either `warn`, `error' or `off`. `warn` is the default.
+     * If you change this, please do so before setting any other properties.
+     * 
+     * @type {string}
+     */
+    this.logLevel = 'warn';
+
     this.eventEmitter = new Phaser.Events.EventEmitter();
 
     validateConfig(this);

--- a/src/Weapon.js
+++ b/src/Weapon.js
@@ -605,7 +605,7 @@ class Weapon {
       });
 
       this.bullets.children.each(function(child) {
-        child.data.bulletManager = this;
+        child.setData('bulletManager', this);
       }, this);
 
       this.bulletKey = key;
@@ -652,8 +652,8 @@ class Weapon {
   pauseAll() {
     this.bullets.children.each(child => {
       child.body.enable = false;
-      if (child.data.timeEvent !== null) {
-        child.data.timeEvent.paused = true;
+      if (child.getData('timeEvent') !== null) {
+        child.getData('timeEvent').paused = true;
       }
     }, this);
 
@@ -670,8 +670,8 @@ class Weapon {
   resumeAll() {
     this.bullets.children.each(child => {
       child.body.enable = true;
-      if (child.data.timeEvent !== null) {
-        child.data.timeEvent.paused = false;
+      if (child.getData('timeEvent') !== null) {
+        child.getData('timeEvent').paused = false;
       }
     }, this);
 
@@ -1047,29 +1047,31 @@ class Weapon {
 
     if (this.autoExpandBulletsGroup) {
       bullet = this.bullets.getFirstDead(true, fromX, fromY, this.bulletKey, this.bulletFrame);
-      bullet.data.bulletManager = this;
+      bullet.setData('bulletManager', this);
     } else {
       bullet = this.bullets.getFirstDead(false);
     }
 
     if (bullet) {
       bullet.prepare(fromX, fromY);
-      bullet.data.fromX = fromX;
-      bullet.data.fromY = fromY;
-      bullet.data.killType = this.bulletKillType;
-      bullet.data.killDistance = this.bulletKillDistance;
-      bullet.data.rotateToVelocity = this.bulletRotateToVelocity;
+      bullet.setData({
+        fromX,
+        fromY,
+        killType: this.bulletKillType,
+        killDistance: this.bulletKillDistance,
+        rotateToVelocity: this.bulletRotateToVelocity,
+      });
 
       if (this.bulletKillType === consts.KILL_LIFESPAN) {
         if (this.bulletLifespan <= 0) {
           throw new Error('Invalid bulletLifespan; must be > 0');
         }
-        bullet.data.timeEvent = this.scene.time.addEvent({
+        bullet.setData('timeEvent', this.scene.time.addEvent({
           delay: this.bulletLifespan,
           // TODO: test to see if we can just pass callbackContext: bullet and
           // have it work. no need to re-bind every time we fire a bullet
           callback: bullet.kill.bind(bullet),
-        });
+        }));
         bullet.lifespan = this.bulletLifespan;
       }
 
@@ -1089,7 +1091,7 @@ class Weapon {
         bullet.setTexture(this.bulletKey, nextFrame);
       }
 
-      if (bullet.data.bodyDirty) {
+      if (bullet.getData('bodyDirty')) {
         if (this._data.customBody) {
           bullet.body.setSize(this._data.width, this._data.height);
           bullet.body.setOffset(this._data.offsetX, this._data.offsetY);
@@ -1097,7 +1099,7 @@ class Weapon {
 
         bullet.body.collideWorldBounds = this.bulletCollideWorldBounds;
 
-        bullet.data.bodyDirty = false;
+        bullet.setData('bodyDirty', false);
       }
 
       bullet.body.setVelocity(moveX, moveY);

--- a/src/Weapon.js
+++ b/src/Weapon.js
@@ -417,6 +417,123 @@ class Weapon {
   }
 
   /**
+ * The Class of the bullets that are launched by this Weapon. Defaults to {@link Phaser.Bullet}, but can be
+ * overridden before calling `createBullets` and set to your own class type.
+ *
+ * It should be a constructor function accepting `(game, x, y, key, frame)`.
+ *
+ * @property {function} bulletClass
+ */
+  get bulletClass() {
+    return this._bulletClass;
+  }
+  set bulletClass(classType){
+    this._bulletClass = classType;
+
+    // `this.bullets` exists only after createBullets()
+    if (this.bullets) {
+      this.bullets.classType = this._bulletClass;
+    }
+  }
+
+  /**
+ * This controls how the bullets will be killed. The default is `consts.KILL_WORLD_BOUNDS`.
+ *
+ * There are 7 different "kill types" available:
+ *
+ * * `consts.KILL_NEVER`
+ * The bullets are never destroyed by the Weapon. It's up to you to destroy them via your own code.
+ *
+ * * `consts.KILL_LIFESPAN`
+ * The bullets are automatically killed when their `bulletLifespan` amount expires.
+ *
+ * * `consts.KILL_DISTANCE`
+ * The bullets are automatically killed when they
+ * exceed `bulletDistance` pixels away from their original launch position.
+ *
+ * * `consts.KILL_WEAPON_BOUNDS`
+ * The bullets are automatically killed when they no longer intersect with the {@link #bounds} rectangle.
+ *
+ * * `consts.KILL_CAMERA_BOUNDS`
+ * The bullets are automatically killed when they no longer intersect with the {@link Phaser.Camera#bounds} rectangle.
+ *
+ * * `consts.KILL_WORLD_BOUNDS`
+ * The bullets are automatically killed when they no longer intersect with the {@link Phaser.World#bounds} rectangle.
+ *
+ * * `consts.KILL_STATIC_BOUNDS`
+ * The bullets are automatically killed when they no longer intersect with the {@link #bounds} rectangle.
+ * The difference between static bounds and weapon bounds, is that a static bounds will never be adjusted to
+ * match the position of a tracked sprite or pointer.
+ *
+ * @property {integer} bulletKillType
+ */
+  get bulletKillType(){
+    return this._bulletKillType;
+  }
+  set bulletKillType(type){
+    switch (type) {
+      case consts.KILL_STATIC_BOUNDS:
+      case consts.KILL_WEAPON_BOUNDS:
+        this.bulletBounds = this.bounds;
+        break;
+
+      case consts.KILL_CAMERA_BOUNDS:
+        this.bulletBounds = this.scene.sys.cameras.main._bounds;
+        break;
+
+      case consts.KILL_WORLD_BOUNDS:
+        this.bulletBounds = this.scene.physics.world.bounds;
+        break;
+    }
+
+    this._bulletKillType = type;
+  }
+
+  /**
+ * Should bullets collide with the World bounds or not?
+ *
+ * @property {boolean} bulletCollideWorldBounds
+ */
+  get bulletCollideWorldBounds(){
+    return this._bulletCollideWorldBounds;
+  }
+  set bulletCollideWorldBounds(value){
+    this._bulletCollideWorldBounds = value;
+
+    this.bullets.children.each(child => {
+      child.body.collideWorldBounds = value;
+      child.setData('bodyDirty', false);
+    });
+  }
+
+  /**
+ * The x coordinate from which bullets are fired. This is the same as `Weapon.fireFrom.x`, and
+ * can be overridden by the {@link #fire} arguments.
+ *
+ * @property {number} x
+ */
+  get x(){
+    return this.fireFrom.x;
+  }
+  set x(value){
+    this.fireFrom.x = value;
+  }
+
+  /**
+ * The y coordinate from which bullets are fired. This is the same as `Weapon.fireFrom.y`, and
+ * can be overridden by the {@link #fire} arguments.
+ *
+ * @name Weapon#y
+ * @property {number} y
+ */
+  get y(){
+    return this.fireFrom.y;
+  }
+  set y(value){
+    this.fireFrom.y = value;
+  }
+
+  /**
    * This method performs two actions: First it will check to see if the
    * {@link #bullets} Group exists or not, and if not it creates it, adding its
    * children to the `group` given as the 4th argument.
@@ -1226,141 +1343,5 @@ class Weapon {
     this.bullets.destroy(true);
   }
 }
-
-/**
- * The Class of the bullets that are launched by this Weapon. Defaults to {@link Phaser.Bullet}, but can be
- * overridden before calling `createBullets` and set to your own class type.
- *
- * It should be a constructor function accepting `(game, x, y, key, frame)`.
- *
- * @name Weapon#bulletClass
- * @property {function} bulletClass
- */
-Object.defineProperty(Weapon.prototype, 'bulletClass', {
-  get() {
-    return this._bulletClass;
-  },
-
-  set(classType) {
-    this._bulletClass = classType;
-
-    // `this.bullets` exists only after createBullets()
-    if (this.bullets) {
-      this.bullets.classType = this._bulletClass;
-    }
-  },
-});
-
-/**
- * This controls how the bullets will be killed. The default is `consts.KILL_WORLD_BOUNDS`.
- *
- * There are 7 different "kill types" available:
- *
- * * `consts.KILL_NEVER`
- * The bullets are never destroyed by the Weapon. It's up to you to destroy them via your own code.
- *
- * * `consts.KILL_LIFESPAN`
- * The bullets are automatically killed when their `bulletLifespan` amount expires.
- *
- * * `consts.KILL_DISTANCE`
- * The bullets are automatically killed when they
- * exceed `bulletDistance` pixels away from their original launch position.
- *
- * * `consts.KILL_WEAPON_BOUNDS`
- * The bullets are automatically killed when they no longer intersect with the {@link #bounds} rectangle.
- *
- * * `consts.KILL_CAMERA_BOUNDS`
- * The bullets are automatically killed when they no longer intersect with the {@link Phaser.Camera#bounds} rectangle.
- *
- * * `consts.KILL_WORLD_BOUNDS`
- * The bullets are automatically killed when they no longer intersect with the {@link Phaser.World#bounds} rectangle.
- *
- * * `consts.KILL_STATIC_BOUNDS`
- * The bullets are automatically killed when they no longer intersect with the {@link #bounds} rectangle.
- * The difference between static bounds and weapon bounds, is that a static bounds will never be adjusted to
- * match the position of a tracked sprite or pointer.
- *
- * @name Weapon#bulletKillType
- * @property {integer} bulletKillType
- */
-Object.defineProperty(Weapon.prototype, 'bulletKillType', {
-  get() {
-    return this._bulletKillType;
-  },
-
-  set(type) {
-    switch (type) {
-      case consts.KILL_STATIC_BOUNDS:
-      case consts.KILL_WEAPON_BOUNDS:
-        this.bulletBounds = this.bounds;
-        break;
-
-      case consts.KILL_CAMERA_BOUNDS:
-        this.bulletBounds = this.scene.sys.cameras.main._bounds;
-        break;
-
-      case consts.KILL_WORLD_BOUNDS:
-        this.bulletBounds = this.scene.physics.world.bounds;
-        break;
-    }
-
-    this._bulletKillType = type;
-  },
-});
-
-/**
- * Should bullets collide with the World bounds or not?
- *
- * @name Weapon#bulletCollideWorldBounds
- * @property {boolean} bulletCollideWorldBounds
- */
-Object.defineProperty(Weapon.prototype, 'bulletCollideWorldBounds', {
-  get() {
-    return this._bulletCollideWorldBounds;
-  },
-
-  set(value) {
-    this._bulletCollideWorldBounds = value;
-
-    this.bullets.children.each(child => {
-      child.body.collideWorldBounds = value;
-      child.data.bodyDirty = false;
-    });
-  },
-});
-
-/**
- * The x coordinate from which bullets are fired. This is the same as `Weapon.fireFrom.x`, and
- * can be overridden by the {@link #fire} arguments.
- *
- * @name Weapon#x
- * @property {number} x
- */
-Object.defineProperty(Weapon.prototype, 'x', {
-  get() {
-    return this.fireFrom.x;
-  },
-
-  set(value) {
-    this.fireFrom.x = value;
-  },
-});
-
-/**
- * The y coordinate from which bullets are fired. This is the same as `Weapon.fireFrom.y`, and
- * can be overridden by the {@link #fire} arguments.
- *
- * @name Weapon#y
- * @property {number} y
- */
-Object.defineProperty(Weapon.prototype, 'y', {
-  get() {
-    return this.fireFrom.y;
-  },
-
-  set(value) {
-    this.fireFrom.y = value;
-  },
-});
 
 export default Weapon;

--- a/src/Weapon.js
+++ b/src/Weapon.js
@@ -417,13 +417,13 @@ class Weapon {
   }
 
   /**
- * The Class of the bullets that are launched by this Weapon. Defaults to {@link Phaser.Bullet}, but can be
- * overridden before calling `createBullets` and set to your own class type.
- *
- * It should be a constructor function accepting `(game, x, y, key, frame)`.
- *
- * @property {function} bulletClass
- */
+   * The Class of the bullets that are launched by this Weapon. Defaults to {@link Phaser.Bullet}, but can be
+   * overridden before calling `createBullets` and set to your own class type.
+   *
+   * It should be a constructor function accepting `(game, x, y, key, frame)`.
+   *
+   * @property {function} bulletClass
+  */
   get bulletClass() {
     return this._bulletClass;
   }
@@ -437,36 +437,36 @@ class Weapon {
   }
 
   /**
- * This controls how the bullets will be killed. The default is `consts.KILL_WORLD_BOUNDS`.
- *
- * There are 7 different "kill types" available:
- *
- * * `consts.KILL_NEVER`
- * The bullets are never destroyed by the Weapon. It's up to you to destroy them via your own code.
- *
- * * `consts.KILL_LIFESPAN`
- * The bullets are automatically killed when their `bulletLifespan` amount expires.
- *
- * * `consts.KILL_DISTANCE`
- * The bullets are automatically killed when they
- * exceed `bulletDistance` pixels away from their original launch position.
- *
- * * `consts.KILL_WEAPON_BOUNDS`
- * The bullets are automatically killed when they no longer intersect with the {@link #bounds} rectangle.
- *
- * * `consts.KILL_CAMERA_BOUNDS`
- * The bullets are automatically killed when they no longer intersect with the {@link Phaser.Camera#bounds} rectangle.
- *
- * * `consts.KILL_WORLD_BOUNDS`
- * The bullets are automatically killed when they no longer intersect with the {@link Phaser.World#bounds} rectangle.
- *
- * * `consts.KILL_STATIC_BOUNDS`
- * The bullets are automatically killed when they no longer intersect with the {@link #bounds} rectangle.
- * The difference between static bounds and weapon bounds, is that a static bounds will never be adjusted to
- * match the position of a tracked sprite or pointer.
- *
- * @property {integer} bulletKillType
- */
+   * This controls how the bullets will be killed. The default is `consts.KILL_WORLD_BOUNDS`.
+   *
+   * There are 7 different "kill types" available:
+   *
+   * * `consts.KILL_NEVER`
+   * The bullets are never destroyed by the Weapon. It's up to you to destroy them via your own code.
+   *
+   * * `consts.KILL_LIFESPAN`
+   * The bullets are automatically killed when their `bulletLifespan` amount expires.
+   *
+   * * `consts.KILL_DISTANCE`
+   * The bullets are automatically killed when they
+   * exceed `bulletDistance` pixels away from their original launch position.
+   *
+   * * `consts.KILL_WEAPON_BOUNDS`
+   * The bullets are automatically killed when they no longer intersect with the {@link #bounds} rectangle.
+   *
+   * * `consts.KILL_CAMERA_BOUNDS`
+   * The bullets are automatically killed when they no longer intersect with the {@link Phaser.Camera#bounds} rectangle.
+   *
+   * * `consts.KILL_WORLD_BOUNDS`
+   * The bullets are automatically killed when they no longer intersect with the {@link Phaser.World#bounds} rectangle.
+   *
+   * * `consts.KILL_STATIC_BOUNDS`
+   * The bullets are automatically killed when they no longer intersect with the {@link #bounds} rectangle.
+   * The difference between static bounds and weapon bounds, is that a static bounds will never be adjusted to
+   * match the position of a tracked sprite or pointer.
+   *
+   * @property {integer} bulletKillType
+  */
   get bulletKillType(){
     return this._bulletKillType;
   }
@@ -490,10 +490,10 @@ class Weapon {
   }
 
   /**
- * Should bullets collide with the World bounds or not?
- *
- * @property {boolean} bulletCollideWorldBounds
- */
+   * Should bullets collide with the World bounds or not?
+   *
+   * @property {boolean} bulletCollideWorldBounds
+  */
   get bulletCollideWorldBounds(){
     return this._bulletCollideWorldBounds;
   }
@@ -507,11 +507,11 @@ class Weapon {
   }
 
   /**
- * The x coordinate from which bullets are fired. This is the same as `Weapon.fireFrom.x`, and
- * can be overridden by the {@link #fire} arguments.
- *
- * @property {number} x
- */
+   * The x coordinate from which bullets are fired. This is the same as `Weapon.fireFrom.x`, and
+   * can be overridden by the {@link #fire} arguments.
+   *
+   * @property {number} x
+  */
   get x(){
     return this.fireFrom.x;
   }
@@ -520,12 +520,11 @@ class Weapon {
   }
 
   /**
- * The y coordinate from which bullets are fired. This is the same as `Weapon.fireFrom.y`, and
- * can be overridden by the {@link #fire} arguments.
- *
- * @name Weapon#y
- * @property {number} y
- */
+   * The y coordinate from which bullets are fired. This is the same as `Weapon.fireFrom.y`, and
+   * can be overridden by the {@link #fire} arguments.
+   *
+   * @property {number} y
+  */
   get y(){
     return this.fireFrom.y;
   }

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -1,13 +1,40 @@
 import consts from './consts';
 
+function log(text, logLevel){
+  if(logLevel === 'warn'){
+    console.warn(text);
+  } else if (logLevel === 'error'){
+    throw new Error(text);
+  }
+}
+
 export default function validateConfig(weapon, property){
-  if (['bulletWorldWrap', 'bulletKillType'].includes(property) && weapon.bulletWorldWrap && (weapon.bulletKillType === consts.KILL_WORLD_BOUNDS || weapon.bulletKillType === consts.KILL_WEAPON_BOUNDS)){
-    console.warn('Warning: KILL_WORLD_BOUNDS and KILL_WEAPON_BOUNDS does not work well with bulletWorldWrap set to true.');
+  if (
+    ['bulletWorldWrap', 'bulletKillType'].includes(property) && 
+    weapon.bulletWorldWrap && 
+    (weapon.bulletKillType === consts.KILL_WORLD_BOUNDS || 
+      weapon.bulletKillType === consts.KILL_WEAPON_BOUNDS)
+  ){
+    log(
+      'Warning: KILL_WORLD_BOUNDS and KILL_WEAPON_BOUNDS does not work well with bulletWorldWrap set to true.', 
+      weapon.logLevel
+    );
   }
-  if (['bulletKillType', 'bulletLifespan'].includes(property) && weapon.bulletKillType === consts.KILL_LIFESPAN && weapon.bulletLifespan <= 0) {
-    throw new Error('Invalid bulletLifespan; must be > 0');
+  if (['bulletKillType', 'bulletLifespan'].includes(property) && 
+  weapon.bulletKillType === consts.KILL_LIFESPAN && 
+  weapon.bulletLifespan <= 0
+  ) {
+    log('Invalid bulletLifespan; must be > 0', weapon.logLevel);
   }
-  if (['fireLimit', 'fireRate', 'fireRateVariance', 'bulletAngleVariance', 'bulletSpeedVariance','bulletKillDistance'].includes(property) && weapon[property] < 0){
-    throw new Error('Invalid ' + property + '; must be >= 0');
+  if (
+    ['fireLimit', 
+      'fireRate', 
+      'fireRateVariance', 
+      'bulletAngleVariance', 
+      'bulletSpeedVariance',
+      'bulletKillDistance'].includes(property) && 
+    weapon[property] < 0
+  ){
+    log('Invalid ' + property + '; must be >= 0', weapon.logLevel);
   }
 }

--- a/src/validateConfig.js
+++ b/src/validateConfig.js
@@ -1,0 +1,13 @@
+import consts from './consts';
+
+export default function validateConfig(weapon, property){
+  if (['bulletWorldWrap', 'bulletKillType'].includes(property) && weapon.bulletWorldWrap && (weapon.bulletKillType === consts.KILL_WORLD_BOUNDS || weapon.bulletKillType === consts.KILL_WEAPON_BOUNDS)){
+    console.warn('Warning: KILL_WORLD_BOUNDS and KILL_WEAPON_BOUNDS does not work well with bulletWorldWrap set to true.');
+  }
+  if (['bulletKillType', 'bulletLifespan'].includes(property) && weapon.bulletKillType === consts.KILL_LIFESPAN && weapon.bulletLifespan <= 0) {
+    throw new Error('Invalid bulletLifespan; must be > 0');
+  }
+  if (['fireLimit', 'fireRate', 'fireRateVariance', 'bulletAngleVariance', 'bulletSpeedVariance','bulletKillDistance'].includes(property) && weapon[property] < 0){
+    throw new Error('Invalid ' + property + '; must be >= 0');
+  }
+}


### PR DESCRIPTION
I've implemented some sort of config validation step. It's still a bit rough, ~~with no option to turn logging off (and no strict mode)~~ EDIT: it now has a logLevel property. Basically all config properties of the weapon are now hidden behind getters/setters, and they call a validateConfig function on setting, and passes along the property name. This function then check if anything is wrong.

This PR also contains some other unrelated commits ~~I haven't pushed to master yet~~ I have since pushed to master.