### PR TITLE
fix: fix eventEmitter being called instead of eventEmitter.emit

### DIFF
--- a/src/Weapon.js
+++ b/src/Weapon.js
@@ -1591,7 +1591,7 @@ class Weapon {
       this.eventEmitter.emit('fire', bullet, this, speed);
 
       if (this.fireLimit > 0 && this.shots === this.fireLimit) {
-        this.eventEmitter('firelimit', this, this.fireLimit);
+        this.eventEmitter.emit('firelimit', this, this.fireLimit);
       }
     }
 


### PR DESCRIPTION
Fixes an issue when using fireRate and the eventEmitter being called incorrectly (causing an error)

<img width="1657" alt="Screenshot 2019-10-01 at 10 11 15 pm" src="https://user-images.githubusercontent.com/19327853/65960800-9fe11100-e498-11e9-8022-f75f8793f7a0.png">